### PR TITLE
Add dockerfile to build project into a container and run it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.4
+
+COPY /requirements.txt /app/requirements.txt
+
+RUN pip install -r /app/requirements.txt
+
+COPY / /app
+
+RUN cd /app/src && ./manage.py migrate
+
+WORKDIR /app/src
+
+EXPOSE 8000
+CMD ["./manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,31 @@
 FROM python:3.4
 
+# Install the dependencies before copying the source code
+# as this prevents frequent docker  build commands from having
+# to keep re-installing the same dependencies over and over
 COPY /requirements.txt /app/requirements.txt
-
 RUN pip install -r /app/requirements.txt
 
+
+# Copy the local directory into the app directory
 COPY / /app
 
-RUN cd /app/src && ./manage.py migrate
-
+# All subsequent docker commands will use this path as its root
 WORKDIR /app/src
 
+# As per the install instructions - run the migration task
+RUN ./manage.py migrate
+
+
+
+# This allows the container to be started with the current source
+# code mounted into it by using
+#   docker run -it --rm -p 8000:8000 -v .:/app ripe-atlas-halo
+VOLUME /app
+
+# Ensure that the django port is presented to the user
 EXPOSE 8000
+
+
+# Run the application by default
 CMD ["./manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ easy.  Just do the following:
 7. Run `./manage.py runserver`
 8. Open a browser and point it at http://localhost:8000/
 
+## Docker Version
+
+1. docker build . -t ripe-atlas-halo
+1. docker run --rm -d -P ripe-atlas-halo
+1. Open a browser and point it at http://localhost:8000/
+
 ## Colophon
 
 This project was named *"Halo"* after the video game by the same name.  It's a

--- a/README.md
+++ b/README.md
@@ -18,9 +18,23 @@ easy.  Just do the following:
 
 ## Docker Version
 
-1. docker build . -t ripe-atlas-halo
-1. docker run --rm -d -P ripe-atlas-halo
-1. Open a browser and point it at http://localhost:8000/
+You can build, and start the ripe-atlas-halo project as a docker container using
+the following commands.
+
+The first will command docker to execute the Dockerfile and create a new local
+image on your workstation which contains the current src of the project, along
+with the required dependencies based on requirements.txt
+
+The second command starts the container for use.
+
+    docker build -t ripe-atlas-halo .
+    docker run -d -name my-ripe-atlas-halo -p 8000:8000 ripe-atlas-halo
+
+Once the container has started, you can navigate to the interface on http://localhost:8000/
+
+To stop the container, simply run
+
+    docker stop my-ripe-atlas-halo
 
 ## Colophon
 
@@ -30,4 +44,3 @@ dashboard... which is what this is.
 
 Give us a break, we had limited time and more important things to do than pick
 a name ;-)
-


### PR DESCRIPTION
Nothing too clever, but this is much easier when using Docker on local machines.

Basically creates a container that performs the installation of requirements anytime it changes, and then runs a migrate.

The docker run is super fast, listens on 0.0.0.0 to let docker route requests to port 8000 which is exposed out of the container automatically.
